### PR TITLE
fix: get-started-button redirects to register page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,12 +47,14 @@ export default function LandingPage() {
                 </p>
               </div>
               <div className="space-x-4">
+                <Link href={"/auth/register"}>
                 <Button
                   size="lg"
                   className="bg-primary text-primary-foreground hover:bg-primary/90"
                 >
                   Get Started
                 </Button>
+                </Link>
                 <Button variant="outline" size="lg">
                   Learn More
                   <a href=""></a>


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR solve the problem of get-started button on homepage not redirecting to auth/register.

Fixes #42 and closes it

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing
Locally

## Screenshots/Videos
Not required

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
